### PR TITLE
add codecov with no codecov file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: node_js
+
+after_script:
+  # Report coverage to codecov
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 Little repo to see how/if codecov.io pays attention to the YAML file.
 
 Starting with adding travis
+
+- add codecov


### PR DESCRIPTION
This adds codecov to travis without a `codecov.yml` being present on master. Notice: coverage is not reported to codecov.io (presumably because the file is not present on master):

![image](https://cloud.githubusercontent.com/assets/253202/22162510/faf50260-df1c-11e6-94d0-612381cdf9d7.png)
