### PR TITLE
Add codecov with file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: node_js
+
+after_script:
+  # Report coverage to codecov
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 Little repo to see how/if codecov.io pays attention to the YAML file.
 
 Starting with adding travis
+
+- add codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+# Use defaults


### PR DESCRIPTION
Seeing what happens when `master` does not have a `codecov.yml` file present.

![image](https://cloud.githubusercontent.com/assets/253202/22163312/444ad1a8-df20-11e6-95cc-6fd3d30b8eaf.png)
